### PR TITLE
Add endpoint for adding new entries with type 'news'

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ require('dotenv').config()
 const indexRouter = require('./routes/index');
 const usersRouter = require('./routes/users');
 const authRouter = require('./routes/auth')
+const newsRouter = require('./routes/news')
 
 const app = express();
 app.use(cors())
@@ -26,6 +27,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
 app.use('/auth', authRouter)
+app.use('/news', newsRouter)
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
@@ -42,5 +44,9 @@ app.use(function(err, req, res, next) {
   res.status(err.status || 500);
   res.render('error');
 });
+
+app.listen(3001, () => {
+  console.log('server running on PORT 3001')
+})
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -45,8 +45,4 @@ app.use(function(err, req, res, next) {
   res.render('error');
 });
 
-app.listen(3001, () => {
-  console.log('server running on PORT 3001')
-})
-
 module.exports = app;

--- a/controllers/newsController.js
+++ b/controllers/newsController.js
@@ -1,0 +1,38 @@
+const db = require('../models')
+const { validationResult } = require("express-validator")
+
+const newsControllers = {
+    add: async (req, res) => {
+        //Check if there is any error
+        const errors = validationResult(req)
+
+        if (!errors.isEmpty()) {
+            let errorMessages = ''
+
+            //List of errors
+            errors.array().map(error => {
+                errorMessages += error.msg + '. '
+            })
+
+            return res.status(401).send(errorMessages)
+        }
+        
+        //Else Save in db
+        const { name, content, image, categoryId } = req.body
+
+        const entryObj = {
+            name,
+            content,
+            image,
+            categoryId,
+            type: 'news',
+            createdAt: new Date,
+            updatedAt: new Date
+        }
+
+        const newEntry = new db.Entries(entryObj)
+        return res.json( await newEntry.save() )
+    }
+}
+
+module.exports = newsControllers

--- a/middlewares/newsValidator.js
+++ b/middlewares/newsValidator.js
@@ -1,0 +1,19 @@
+const expressValidator = require('express-validator')
+const { body } = expressValidator
+
+const newsValidator = [
+    body("name")
+        .not().isEmpty()
+        .withMessage("Por favor escribe un nombre válido"),
+    body("content")
+        .not().isEmpty()
+        .withMessage("Por favor escribe un contenido válido"),
+    body("image")
+        .not().isEmpty()
+        .withMessage("Por favor ingresa una imagen válida"),
+    body("categoryId")
+        .not().isEmpty()
+        .withMessage("Por favor ingresa un categoryId válido")
+]
+
+module.exports = newsValidator

--- a/routes/news.js
+++ b/routes/news.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const router = express.Router()
+
+const newsController = require('../controllers/newsController.js')
+const newsValidator = require('../middlewares/newsValidator')
+
+//POST add new entry to "Entries" with type "news"
+router.post('/', newsValidator, newsController.add)
+
+module.exports = router


### PR DESCRIPTION
task url: https://alkemy-labs.atlassian.net/browse/OT289-56

## Description:
Added an endpoint for saving new entries as type 'news'.
Data received is first validated, then "type": 'news' is added and finally saved to db and returning the saved object.

Already tested, working as expected with OT289-41 (https://alkemy-labs.atlassian.net/browse/OT289-41)

## Evidence:
https://user-images.githubusercontent.com/53307135/191868353-3abe749c-c6a2-4d45-8ea9-6afa1e3195e7.mp4

