### PR TITLE
endpoint-organization-redes/ot289-80

### DIFF
--- a/controllers/MOCK_DATA.json
+++ b/controllers/MOCK_DATA.json
@@ -15,11 +15,16 @@
                 "url": "https://twitter.com"
             }
         ],
-        "name": "Maddy Djorvic",
-        "image": "http://dummyimage.com/152x100.png/ff4444/ffffff",
-        "phone": "788-137-8279",
-        "address": "831 Sachs Terrace",
-        "welcomeText": "Morbi a ipsum. Integer a nibh. In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet. Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui. Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti. Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris. Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis. Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem. Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus. Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia."
+        "name": "Somos Más",
+        "founders": [
+            "Maria Irola, Marita Gomez"
+        ],
+        "colaborators": [
+            "Miriam Rodriguez, Cecilia Mendez, Mario Fuentes, Rodrigo Fuente, Maria Garcia, Marco Fernandez"
+        ],
+        "phone": "1160112988",
+        "email": "somosfundacionmas@gmail.com",
+        "welcomeText": "Desde 1997 en Somos Más trabajamos con los chicos y chicas, mamás y papás, abuelos y vecinos del barrio La Cava generando procesos de crecimiento y de inserción social. Uniendo las manos de todas las familias, las que viven en el barrio y las que viven fuera de él, es que podemos pensar, crear y garantizar estos procesos. Somos una asociación civil sin fines de lucro que se creó en 1997 con la intención de dar alimento a las familias del barrio. Con el tiempo fuimos involucrándonos con la comunidad y agrandando y mejorando nuestra capacidad de trabajo. Hoy somos un centro comunitario que acompaña a más de 700 personas a través de las áreas de: Educación, deportes, primera infancia, salud, alimentación y trabajo social."
     },
     {
         "id": 2,

--- a/controllers/MOCK_DATA.json
+++ b/controllers/MOCK_DATA.json
@@ -1,10 +1,20 @@
 [
     {
         "id": 1,
-        "socialLinks": {
-            "name": "Instagram",
-            "url": "https://instagram.com"
-        },
+        "socialLinks": [
+            {
+                "name": "Instagram",
+                "url": "https://instagram.com"
+            },
+            {
+                "name": "Facebook",
+                "url": "https://facebook.com"
+            },
+            {
+                "name": "Twitter",
+                "url": "https://twitter.com"
+            }
+        ],
         "name": "Maddy Djorvic",
         "image": "http://dummyimage.com/152x100.png/ff4444/ffffff",
         "phone": "788-137-8279",
@@ -13,10 +23,6 @@
     },
     {
         "id": 2,
-        "socialLinks": {
-            "name": "Facebook",
-            "url": "https://facebook.com"
-        },
         "name": "Hilde Santacrole",
         "image": "http://dummyimage.com/235x100.png/ff4444/ffffff",
         "phone": "417-214-0461",
@@ -25,10 +31,6 @@
     },
     {
         "id": 3,
-        "socialLinks": {
-            "name": "Twitter",
-            "url": "https://twitter.com"
-        },
         "name": "Vincents Bordessa",
         "image": "http://dummyimage.com/202x100.png/cc0000/ffffff",
         "phone": "797-887-9085",
@@ -37,10 +39,6 @@
     },
     {
         "id": 4,
-        "socialLinks": {
-            "name": "Instagram",
-            "url": "https://instagram.com"
-        },
         "name": "Nanny Roycroft",
         "image": "http://dummyimage.com/175x100.png/5fa2dd/ffffff",
         "phone": "651-327-7079",
@@ -49,10 +47,6 @@
     },
     {
         "id": 5,
-        "socialLinks": {
-            "name": "Facebook",
-            "url": "https://facebook.com"
-        },
         "name": "Konstanze Strase",
         "image": "http://dummyimage.com/139x100.png/ff4444/ffffff",
         "phone": "918-488-9821",
@@ -61,10 +55,6 @@
     },
     {
         "id": 6,
-        "socialLinks": {
-            "name": "Twitter",
-            "url": "https://twitter.com"
-        },
         "name": "Norean Maes",
         "image": "http://dummyimage.com/234x100.png/dddddd/000000",
         "phone": "596-955-5716",
@@ -73,10 +63,6 @@
     },
     {
         "id": 7,
-        "socialLinks": {
-            "name": "Instagram",
-            "url": "https://instagram.com"
-        },
         "name": "Luigi Dallosso",
         "image": "http://dummyimage.com/167x100.png/5fa2dd/ffffff",
         "phone": "645-593-4541",
@@ -85,10 +71,6 @@
     },
     {
         "id": 8,
-        "socialLinks": {
-            "name": "Facebook",
-            "url": "https://facebook.com"
-        },
         "name": "Anallise Northcott",
         "image": "http://dummyimage.com/241x100.png/dddddd/000000",
         "phone": "562-131-2121",
@@ -97,10 +79,6 @@
     },
     {
         "id": 9,
-        "socialLinks": {
-            "name": "Twitter",
-            "url": "https://twitter.com"
-        },
         "name": "Kameko Frodsham",
         "image": "http://dummyimage.com/215x100.png/5fa2dd/ffffff",
         "phone": "572-960-5701",

--- a/controllers/MOCK_DATA.json
+++ b/controllers/MOCK_DATA.json
@@ -1,10 +1,110 @@
-[{"id":1,"name":"Maddy Djorvic","image":"http://dummyimage.com/152x100.png/ff4444/ffffff","phone":"788-137-8279","address":"831 Sachs Terrace","welcomeText":"Morbi a ipsum. Integer a nibh. In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet. Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui. Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti. Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris. Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis. Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem. Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus. Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia."},
-{"id":2,"name":"Hilde Santacrole","image":"http://dummyimage.com/235x100.png/ff4444/ffffff","phone":"417-214-0461","address":"2 Cherokee Plaza","welcomeText":"Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem. Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat. Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem. Fusce consequat. Nulla nisl."},
-{"id":3,"name":"Vincents Bordessa","image":"http://dummyimage.com/202x100.png/cc0000/ffffff","phone":"797-887-9085","address":"887 Talisman Circle","welcomeText":"Curabitur convallis. Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus. Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero. Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh. In quis justo. Maecenas rhoncus aliquam lacus."},
-{"id":4,"name":"Nanny Roycroft","image":"http://dummyimage.com/175x100.png/5fa2dd/ffffff","phone":"651-327-7079","address":"6836 2nd Point","welcomeText":"Etiam faucibus cursus urna. Ut tellus. Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi. Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque. Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus. Phasellus in felis. Donec semper sapien a libero. Nam dui. Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius. Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi."},
-{"id":5,"name":"Konstanze Strase","image":"http://dummyimage.com/139x100.png/ff4444/ffffff","phone":"918-488-9821","address":"681 Grim Drive","welcomeText":"In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus. Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst. Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat. Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem. Integer tincidunt ante vel ipsum."},
-{"id":6,"name":"Norean Maes","image":"http://dummyimage.com/234x100.png/dddddd/000000","phone":"596-955-5716","address":"6058 Old Shore Place","welcomeText":"Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio. Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo."},
-{"id":7,"name":"Luigi Dallosso","image":"http://dummyimage.com/167x100.png/5fa2dd/ffffff","phone":"645-593-4541","address":"88 Kings Junction","welcomeText":"Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi. Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque. Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus. Phasellus in felis. Donec semper sapien a libero. Nam dui. Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius. Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi. Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus. Curabitur at ipsum ac tellus semper interdum."},
-{"id":8,"name":"Anallise Northcott","image":"http://dummyimage.com/241x100.png/dddddd/000000","phone":"562-131-2121","address":"66 Esch Center","welcomeText":"Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque. Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus. In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus. Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst. Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat. Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem. Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat. Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem. Fusce consequat. Nulla nisl. Nunc nisl. Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum. In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo. Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis. Sed ante. Vivamus tortor. Duis mattis egestas metus. Aenean fermentum."},
-{"id":9,"name":"Kameko Frodsham","image":"http://dummyimage.com/215x100.png/5fa2dd/ffffff","phone":"572-960-5701","address":"27 Monument Pass","welcomeText":"Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio. Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl. Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum. Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est. Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum. Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem. Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit. Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque. Duis bibendum. Morbi non quam nec dui luctus rutrum."},
-{"id":10,"name":"Siouxie Ward","image":"http://dummyimage.com/193x100.png/ff4444/ffffff","phone":"859-591-9042","address":"4 Dawn Way","welcomeText":"Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti. Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris. Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis. Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem. Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus. Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus."}]
+[
+    {
+        "id": 1,
+        "socialLinks": {
+            "name": "Instagram",
+            "url": "https://instagram.com"
+        },
+        "name": "Maddy Djorvic",
+        "image": "http://dummyimage.com/152x100.png/ff4444/ffffff",
+        "phone": "788-137-8279",
+        "address": "831 Sachs Terrace",
+        "welcomeText": "Morbi a ipsum. Integer a nibh. In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet. Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui. Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti. Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris. Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis. Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem. Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus. Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia."
+    },
+    {
+        "id": 2,
+        "socialLinks": {
+            "name": "Facebook",
+            "url": "https://facebook.com"
+        },
+        "name": "Hilde Santacrole",
+        "image": "http://dummyimage.com/235x100.png/ff4444/ffffff",
+        "phone": "417-214-0461",
+        "address": "2 Cherokee Plaza",
+        "welcomeText": "Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem. Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat. Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem. Fusce consequat. Nulla nisl."
+    },
+    {
+        "id": 3,
+        "socialLinks": {
+            "name": "Twitter",
+            "url": "https://twitter.com"
+        },
+        "name": "Vincents Bordessa",
+        "image": "http://dummyimage.com/202x100.png/cc0000/ffffff",
+        "phone": "797-887-9085",
+        "address": "887 Talisman Circle",
+        "welcomeText": "Curabitur convallis. Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus. Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero. Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh. In quis justo. Maecenas rhoncus aliquam lacus."
+    },
+    {
+        "id": 4,
+        "socialLinks": {
+            "name": "Instagram",
+            "url": "https://instagram.com"
+        },
+        "name": "Nanny Roycroft",
+        "image": "http://dummyimage.com/175x100.png/5fa2dd/ffffff",
+        "phone": "651-327-7079",
+        "address": "6836 2nd Point",
+        "welcomeText": "Etiam faucibus cursus urna. Ut tellus. Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi. Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque. Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus. Phasellus in felis. Donec semper sapien a libero. Nam dui. Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius. Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi."
+    },
+    {
+        "id": 5,
+        "socialLinks": {
+            "name": "Facebook",
+            "url": "https://facebook.com"
+        },
+        "name": "Konstanze Strase",
+        "image": "http://dummyimage.com/139x100.png/ff4444/ffffff",
+        "phone": "918-488-9821",
+        "address": "681 Grim Drive",
+        "welcomeText": "In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus. Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst. Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat. Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem. Integer tincidunt ante vel ipsum."
+    },
+    {
+        "id": 6,
+        "socialLinks": {
+            "name": "Twitter",
+            "url": "https://twitter.com"
+        },
+        "name": "Norean Maes",
+        "image": "http://dummyimage.com/234x100.png/dddddd/000000",
+        "phone": "596-955-5716",
+        "address": "6058 Old Shore Place",
+        "welcomeText": "Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio. Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo."
+    },
+    {
+        "id": 7,
+        "socialLinks": {
+            "name": "Instagram",
+            "url": "https://instagram.com"
+        },
+        "name": "Luigi Dallosso",
+        "image": "http://dummyimage.com/167x100.png/5fa2dd/ffffff",
+        "phone": "645-593-4541",
+        "address": "88 Kings Junction",
+        "welcomeText": "Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi. Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque. Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus. Phasellus in felis. Donec semper sapien a libero. Nam dui. Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius. Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi. Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus. Curabitur at ipsum ac tellus semper interdum."
+    },
+    {
+        "id": 8,
+        "socialLinks": {
+            "name": "Facebook",
+            "url": "https://facebook.com"
+        },
+        "name": "Anallise Northcott",
+        "image": "http://dummyimage.com/241x100.png/dddddd/000000",
+        "phone": "562-131-2121",
+        "address": "66 Esch Center",
+        "welcomeText": "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque. Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus. In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus. Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst. Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat. Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem. Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat. Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem. Fusce consequat. Nulla nisl. Nunc nisl. Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum. In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo. Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis. Sed ante. Vivamus tortor. Duis mattis egestas metus. Aenean fermentum."
+    },
+    {
+        "id": 9,
+        "socialLinks": {
+            "name": "Twitter",
+            "url": "https://twitter.com"
+        },
+        "name": "Kameko Frodsham",
+        "image": "http://dummyimage.com/215x100.png/5fa2dd/ffffff",
+        "phone": "572-960-5701",
+        "address": "27 Monument Pass",
+        "welcomeText": "Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem. Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio. Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl. Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum. Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est. Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum. Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem. Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit. Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque. Duis bibendum. Morbi non quam nec dui luctus rutrum."
+    }
+]


### PR DESCRIPTION
jira link:
https://alkemy-labs.atlassian.net/browse/OT289-80

summary:
the endpoint organizations/:id/public now also has a new field named 'socialLinks' that has 2 keys, name (for the social media name) and url (for the actual web address)

evidence:
<img width="778" alt="Screen Shot 2022-10-03 at 20 05 57" src="https://user-images.githubusercontent.com/99274893/193701707-64464a2e-4558-4436-a9c1-6885a891f07f.png">
