### PR TITLE
Add 'id' attribute to 'getNews', needed for properly navigate to every news detail page

### DIFF
--- a/controllers/newsController.js
+++ b/controllers/newsController.js
@@ -104,7 +104,7 @@ const newsController = {
         where: {
           type: "news",
         },
-        attributes: ["name", "image", "createdAt"],
+        attributes: ["id", "name", "image", "createdAt"],
       });
       news.length
         ? res.status(200).send(news)

--- a/controllers/newsController.js
+++ b/controllers/newsController.js
@@ -106,9 +106,7 @@ const newsController = {
         },
         attributes: ["id", "name", "image", "createdAt"],
       });
-      news.length
-        ? res.status(200).send(news)
-        : res.status(200).send("Not found");
+      res.status(200).send(news)
     } catch (error) {
       res.status(400).send(error.message);
     }

--- a/migrations/20221007232954-update-entries-content.js
+++ b/migrations/20221007232954-update-entries-content.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('Entries', 'content', {
+      type: Sequelize.TEXT,
+      allowNull: false
+    })
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  }
+};


### PR DESCRIPTION
Part of task: https://alkemy-labs.atlassian.net/browse/OT289-109

When GET /news is called, it will now return 'id' attribute as well.

Also, change it to always return its result, even if it is an empty array (needed in client, otherwise it will break the site).

Added new migration for updating 'Entries' -> 'content' type (varchar -> TEXT).