### PR TITLE
Test: Endpoints /contacts

### DIFF
--- a/middlewares/contactsValidator.js
+++ b/middlewares/contactsValidator.js
@@ -9,6 +9,14 @@ const contactsValidator = [
   body("email")
     .isEmail()
     .withMessage("Por favor escribe un email válido"),
+  body("phone")
+    .not()
+    .isEmpty()
+    .withMessage("Por favor escribe un número de contacto válido"),
+  body("message")
+    .not()
+    .isEmpty()
+    .withMessage("Por favor escribe un mensaje válido"),
 ];
 
 module.exports = contactsValidator;

--- a/middlewares/isAdmin.js
+++ b/middlewares/isAdmin.js
@@ -8,8 +8,8 @@ function isAdmin(req,res,next){
    if(typeof bearerHeader !== 'undefined') {
     bearerToken = bearerHeader?.split(' ')[1]
    } else {
-    return res.sendStatus(403)
-   } // Si no manda authorization en headers da 403
+    return res.sendStatus(401)
+   } // Si no manda authorization en headers da 401
 
    if (!bearerToken) {
     return res.sendStatus(404)
@@ -17,13 +17,13 @@ function isAdmin(req,res,next){
 
    jwt.verify(bearerToken, secret, (error, data) => {
         if (error) {
-           return res.send(error)
+           return res.status(401).send(error)
         } else {
          const admin = data.payload.roleId // variable a modificar cuando este el merge de como es el token
          if(admin === 1) {
             next()
          } else {
-            return res.sendStatus(403) // si tu roleId no es 1 (osea administrador) da 403
+            return res.sendStatus(401) // si tu roleId no es 1 (osea administrador) da 403
          }
         }// si el token es invalido da el resultado de error
    })

--- a/middlewares/isAdmin.js
+++ b/middlewares/isAdmin.js
@@ -19,7 +19,7 @@ function isAdmin(req,res,next){
         if (error) {
            return res.send(error)
         } else {
-         const admin = data.roleId // variable a modificar cuando este el merge de como es el token
+         const admin = data.payload.roleId // variable a modificar cuando este el merge de como es el token
          if(admin === 1) {
             next()
          } else {

--- a/seeders/20201109013159-create-demo-user.js
+++ b/seeders/20201109013159-create-demo-user.js
@@ -1,4 +1,5 @@
 'use strict';
+const bcrypt = require('bcrypt')
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
@@ -6,8 +7,7 @@ module.exports = {
       firstName: 'Usuario',
       lastName: 'Demo',
       email: 'test@test.com',
-      // Important: Password not encrypted yet! 
-      password: '1234',
+      password: bcrypt.hashSync('12345678', 10),
       roleId: 1,
       image: 'https://www.designevo.com/res/templates/thumb_small/colorful-hand-and-warm-community.png',
       createdAt: new Date,

--- a/seeders/20201109013159-create-demo-user.js
+++ b/seeders/20201109013159-create-demo-user.js
@@ -1,18 +1,32 @@
 'use strict';
 const bcrypt = require('bcrypt')
 
+const usersArray = [
+  {
+    firstName: 'Admin',
+    lastName: 'Demo',
+    email: 'admin@test.com',
+    password: bcrypt.hashSync('12345678', 10),
+    roleId: 1,
+    image: 'https://www.designevo.com/res/templates/thumb_small/colorful-hand-and-warm-community.png',
+    createdAt: new Date,
+    updatedAt: new Date
+  },
+  {
+    firstName: 'Usuario',
+    lastName: 'Demo',
+    email: 'usuario@test.com',
+    password: bcrypt.hashSync('12345678', 10),
+    roleId: 2,
+    image: 'https://www.designevo.com/res/templates/thumb_small/colorful-hand-and-warm-community.png',
+    createdAt: new Date,
+    updatedAt: new Date
+  }
+]
+
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkInsert('Users', [{
-      firstName: 'Usuario',
-      lastName: 'Demo',
-      email: 'test@test.com',
-      password: bcrypt.hashSync('12345678', 10),
-      roleId: 1,
-      image: 'https://www.designevo.com/res/templates/thumb_small/colorful-hand-and-warm-community.png',
-      createdAt: new Date,
-      updatedAt: new Date
-    }], {});
+    await queryInterface.bulkInsert('Users', usersArray, {});
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/test/contacts.test.js
+++ b/test/contacts.test.js
@@ -74,17 +74,17 @@ describe('POST /contacts', () => {
     }
 
     it('It should return status code 200 if all data needed is sent', async () => {
-        const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(dummyData)
+        const res = await request(app).post('/contacts').send(dummyData)
         expect(res.status).toBe(200)
     })
 
     it("It should pass if headers type is equal to application/json", async () => {
-        const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(dummyData)
+        const res = await request(app).post('/contacts').send(dummyData)
         expect(res.headers['content-type']).toEqual(expect.stringContaining('json'))
     })
 
     it('It should return "id", "name", "phone", "email" & "message" if contact was saved', async () => {
-        const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(dummyData)
+        const res = await request(app).post('/contacts').send(dummyData)
         expect(res.body).toHaveProperty('id')
         expect(res.body).toHaveProperty('name')
         expect(res.body).toHaveProperty('phone')
@@ -93,13 +93,13 @@ describe('POST /contacts', () => {
     })
 
     it('It should return status code 400 if route exist but no data is sent', async () => {
-        const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send()
+        const res = await request(app).post('/contacts').send()
         expect(res.status).toBe(400)
     })
 
     describe('Data sent validation', () => {
         it('It should return status code 400 if data is empty', async () => {
-            const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send({})
+            const res = await request(app).post('/contacts').send({})
             expect(res.status).toBe(400)
         })
 
@@ -107,7 +107,7 @@ describe('POST /contacts', () => {
             const data = {...dummyData}
             data.email = 'invalidEmail'
 
-            const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(data)
+            const res = await request(app).post('/contacts').send(data)
             expect(res.status).toBe(400)
         })
 
@@ -116,7 +116,7 @@ describe('POST /contacts', () => {
                 const data = {...dummyData}
                 delete data[prop]
 
-                const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(data)
+                const res = await request(app).post('/contacts').send(data)
                 expect(res.status).toBe(400)
             })
         })
@@ -126,7 +126,7 @@ describe('POST /contacts', () => {
                 const data = {...dummyData}
                 data[prop] = ''
 
-                const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(data)
+                const res = await request(app).post('/contacts').send(data)
                 expect(res.status).toBe(400)
             })
         })

--- a/test/contacts.test.js
+++ b/test/contacts.test.js
@@ -1,0 +1,38 @@
+const app = require('../app.js')
+const request = require('supertest')
+
+//need for testing routes protected
+let adminToken = ''
+
+//get user token with roleId 1 (admin). User is based in demo user created with seeder.
+beforeAll(async () => {
+    const res = await request(app).post('/users/auth/login').send({
+        email: "test@test.com",
+        password: "12345678"
+    })
+    adminToken = res.body.token
+})
+
+//TESTS
+describe('GET /contacts', () => {
+    it('It should return status code 200', async() => {
+        const res = await request(app).get('/contacts').set('Authorization', `Bearer ${adminToken}`)
+
+        expect(res.status).toBe(200)
+    })
+
+    it('It should response an array of objects, each one with properties "name", "phone", "email" & "message"', async() => {
+        const res = await request(app).get('/contacts').set('Authorization', `Bearer ${adminToken}`)
+
+        //Must be an array
+        expect(res.body).toBeInstanceOf(Array)
+
+        //Each contact must contain properties "name", "phone", "email" & "message"
+        res.body.map(contact => {
+            expect(contact).toHaveProperty('name')
+            expect(contact).toHaveProperty('phone')
+            expect(contact).toHaveProperty('email')
+            expect(contact).toHaveProperty('message')
+        })
+    })
+})

--- a/test/contacts.test.js
+++ b/test/contacts.test.js
@@ -1,9 +1,12 @@
 const app = require('../app.js')
 const request = require('supertest')
 
-//need for testing protected routes
+//needed for testing protected routes
 let adminToken = ''
 let userToken = ''
+
+//props needed
+const propsNeeded = ['name', 'phone', 'email', 'message']
 
 //get users token. Users are based in demo users created with seeder.
 beforeAll(async () => {
@@ -34,10 +37,9 @@ describe('GET /contacts', () => {
         expect(res.body).toBeInstanceOf(Array)
 
         res.body.map(contact => {
-            expect(contact).toHaveProperty('name')
-            expect(contact).toHaveProperty('phone')
-            expect(contact).toHaveProperty('email')
-            expect(contact).toHaveProperty('message')
+            propsNeeded.map(prop => {
+                expect(contact).toHaveProperty(prop)
+            })
         })
     })
 
@@ -64,8 +66,6 @@ describe('GET /contacts', () => {
 })
 
 describe('POST /contacts', () => {
-    const propsNeeded = ['name', 'phone', 'email', 'message']
-
     const dummyData = {
         name: 'test',
         phone: '123456',
@@ -85,11 +85,11 @@ describe('POST /contacts', () => {
 
     it('It should return "id", "name", "phone", "email" & "message" if contact was saved', async () => {
         const res = await request(app).post('/contacts').send(dummyData)
+
         expect(res.body).toHaveProperty('id')
-        expect(res.body).toHaveProperty('name')
-        expect(res.body).toHaveProperty('phone')
-        expect(res.body).toHaveProperty('email')
-        expect(res.body).toHaveProperty('message')
+        propsNeeded.map(prop => {
+            expect(res.body).toHaveProperty(prop)
+        })
     })
 
     it('It should return status code 400 if route exist but no data is sent', async () => {

--- a/test/contacts.test.js
+++ b/test/contacts.test.js
@@ -22,13 +22,13 @@ beforeAll(async () => {
 
 //TESTS
 describe('GET /contacts', () => {
-    it('It should return status code 200', async() => {
-        const res = await request(app).get('/contacts').set('Authorization', `Bearer ${adminToken}`)
 
+    it('It should return status code 200', async () => {
+        const res = await request(app).get('/contacts').set('Authorization', `Bearer ${adminToken}`)
         expect(res.status).toBe(200)
     })
 
-    it('It should response an array of objects, each one with properties "name", "phone", "email" & "message"', async() => {
+    it('It should response an array of objects, each one with properties "name", "phone", "email" & "message"', async () => {
         const res = await request(app).get('/contacts').set('Authorization', `Bearer ${adminToken}`)
 
         //Must be an array
@@ -44,23 +44,69 @@ describe('GET /contacts', () => {
     })
 
     describe('Admin token validations', () => {
-        it('It should return status code 401 (Unauthorized) if no token is passed', async() => {
+
+        it('It should return status code 401 (Unauthorized) if no token is passed', async () => {
             const res = await request(app).get('/contacts')
-    
             expect(res.status).toBe(401)
         })
     
-        it('It should return status code 401 (Unauthorized) if no valid token is passed', async() => {
+        it('It should return status code 401 (Unauthorized) if no valid token is passed', async () => {
             const invalidAdminToken = '1234'
             const res = await request(app).get('/contacts').set('Authorization', `Bearer ${invalidAdminToken}`)
     
             expect(res.status).toBe(401)
         })
 
-        it('It should return status code 401 (Unauthorized) if roleId !== 1', async() => {
+        it('It should return status code 401 (Unauthorized) if roleId !== 1 (admin)', async () => {
             const res = await request(app).get('/contacts').set('Authorization', `Bearer ${userToken}`)
-    
             expect(res.status).toBe(401)
+        })
+
+    })
+})
+
+describe('POST /contacts', () => {
+    const propertiesNeeded = ['name', 'phone', 'email', 'message']
+
+    const dummyData = {
+        name: 'test',
+        phone: '123456',
+        email: 'test@test.com',
+        message: 'this is a message test'
+    }
+
+    describe('Data sent validation', () => {
+        it('It should return status code 400 if data is empty', async () => {
+            const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send({})
+            expect(res.status).toBe(400)
+        })
+
+        it('It should return status code 400 if invalid email is passed', async () => {
+            const data = {...dummyData}
+            data.email = 'invalidEmail'
+
+            const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(data)
+            expect(res.status).toBe(400)
+        })
+
+        it('It should return status code 400 if "name", "phone", "email" or "message" are missing', async () => {
+            propertiesNeeded.map(async (prop) => {
+                const data = {...dummyData}
+                delete data[prop]
+
+                const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(data)
+                expect(res.status).toBe(400)
+            })
+        })
+
+        it('It should return status code 400 if "name", "phone", "email" or "message" are empty', async () => {
+            propertiesNeeded.map(async (prop) => {
+                const data = {...dummyData}
+                data[prop] = ''
+
+                const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(data)
+                expect(res.status).toBe(400)
+            })
         })
     })
 })

--- a/test/contacts.test.js
+++ b/test/contacts.test.js
@@ -31,10 +31,8 @@ describe('GET /contacts', () => {
     it('It should response an array of objects, each one with properties "name", "phone", "email" & "message"', async () => {
         const res = await request(app).get('/contacts').set('Authorization', `Bearer ${adminToken}`)
 
-        //Must be an array
         expect(res.body).toBeInstanceOf(Array)
 
-        //Each contact must contain properties "name", "phone", "email" & "message"
         res.body.map(contact => {
             expect(contact).toHaveProperty('name')
             expect(contact).toHaveProperty('phone')
@@ -66,7 +64,7 @@ describe('GET /contacts', () => {
 })
 
 describe('POST /contacts', () => {
-    const propertiesNeeded = ['name', 'phone', 'email', 'message']
+    const propsNeeded = ['name', 'phone', 'email', 'message']
 
     const dummyData = {
         name: 'test',
@@ -74,6 +72,30 @@ describe('POST /contacts', () => {
         email: 'test@test.com',
         message: 'this is a message test'
     }
+
+    it('It should return status code 200 if all data needed is sent', async () => {
+        const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(dummyData)
+        expect(res.status).toBe(200)
+    })
+
+    it("It should pass if headers type is equal to application/json", async () => {
+        const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(dummyData)
+        expect(res.headers['content-type']).toEqual(expect.stringContaining('json'))
+    })
+
+    it('It should return "id", "name", "phone", "email" & "message" if contact was saved', async () => {
+        const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send(dummyData)
+        expect(res.body).toHaveProperty('id')
+        expect(res.body).toHaveProperty('name')
+        expect(res.body).toHaveProperty('phone')
+        expect(res.body).toHaveProperty('email')
+        expect(res.body).toHaveProperty('message')
+    })
+
+    it('It should return status code 400 if route exist but no data is sent', async () => {
+        const res = await request(app).post('/contacts').set('Authorization', `Bearer ${adminToken}`).send()
+        expect(res.status).toBe(400)
+    })
 
     describe('Data sent validation', () => {
         it('It should return status code 400 if data is empty', async () => {
@@ -90,7 +112,7 @@ describe('POST /contacts', () => {
         })
 
         it('It should return status code 400 if "name", "phone", "email" or "message" are missing', async () => {
-            propertiesNeeded.map(async (prop) => {
+            propsNeeded.map(async (prop) => {
                 const data = {...dummyData}
                 delete data[prop]
 
@@ -100,7 +122,7 @@ describe('POST /contacts', () => {
         })
 
         it('It should return status code 400 if "name", "phone", "email" or "message" are empty', async () => {
-            propertiesNeeded.map(async (prop) => {
+            propsNeeded.map(async (prop) => {
                 const data = {...dummyData}
                 data[prop] = ''
 


### PR DESCRIPTION
task url: https://alkemy-labs.atlassian.net/browse/OT289-119

## Description:
Test endpoints for /contacts

GET /contacts should return an array of contacts (only available for admin users)
POST /contacts should save a contact

Made some changes to isAdmin middleware (missing .payload)
Made some changes to contactsValidator middleware (add more fields)
Made some changes to create-demo-user seeder (add 1 admin user with password encrypted, and 1 normal user)

## Evidence:
https://user-images.githubusercontent.com/53307135/196529713-750b7ca7-79a1-4b1d-91ab-3249a6556ed8.mp4
